### PR TITLE
SCCPPGHA-15 Use unified sonarqube-scan-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       - name: install gcovr 5.0
         run: |
           pip install gcovr==5.0 # 5.1 is not supported
-      - name: Install sonar-scanner and build-wrapper
-        uses: sonarsource/sonarcloud-github-c-cpp@v3
-      - name: Run build-wrapper
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
+      - name: Run Build Wrapper
         run: |
           mkdir build
           cmake -S . -B build
@@ -37,11 +37,11 @@ jobs:
       - name: Collect coverage into one XML report
         run: |
           gcovr --sonarqube > coverage.xml
-      - name: Run sonar-scanner
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }} # Put the name of your token here
-        run: |
-          sonar-scanner \
+        with:
+          args: >
             --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" \
             --define sonar.coverageReportPaths=coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,5 +43,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }} # Put the name of your token here
         with:
           args: >
-            --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" \
+            --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
             --define sonar.coverageReportPaths=coverage.xml

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@
 image:{img-build-status}[Build Status, link={uri-build-status}]
 image:{img-qg-status}[Quality Gate Status,link={uri-qg-status}]
 
-*The test coverage shown here works on both SonarQube and SonarCloud. This project is analyzed on https://sonarcloud.io/dashboard?id=sonarsource-cfamily-examples_linux-cmake-gcovr-gh-actions-sc[SonarCloud]!*
+*The test coverage shown here works on both SonarQube Server and Cloud. This project is analyzed on https://sonarcloud.io/dashboard?id=sonarsource-cfamily-examples_linux-cmake-gcovr-gh-actions-sc[SonarQube Cloud]!*
 
 :note-caption: :information_source:
 NOTE: This simple example aims at demonstrating code coverage in action. It explains how to add coverage on a project for which the analysis is already configured. Analysis configuration examples are available <<code-description,here>>. +
@@ -18,26 +18,26 @@ To get coverage and feed it to the sonar-scanner, use the following procedure.
 
 . Add `--coverage` compilation flag to instrument the binaries
 . Run the test binaries to count covered lines
-. Run `gcovr --sonarqube` to produce the SonarQube- and SonarCloud-compatible XML coverage report
+. Run `gcovr --sonarqube` to produce the SonarQube-compatible XML coverage report
 . Point the `sonar.coverageReportPaths` property to the generated coverage-report file
-. Run `sonar-scanner` as the final step
+. Run the SonarQube scan using https://github.com/SonarSource/sonarqube-scan-action[the SonarSource/sonarqube-scan-action action] as final step
 
 You can take a look at the link:sonar-project.properties[sonar-project.properties] and link:.github/workflows/build.yml[build.yml] to see it in practice.
 
 = Documentation
 
-- https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/[Documentation overview of the C, C++ and Objective-C analyzer]
-- https://docs.sonarcloud.io/getting-started/github/[Documentation of using SonarCloud with GitHub]
-- https://docs.sonarcloud.io/advanced-setup/languages/c-family/prerequisites/#generating-a-compilation-database[Generating a compilation database (compile_commands.json)]
-- https://docs.sonarsource.com/sonarcloud/advanced-setup/languages/c-family/running-the-analysis/[Running the analysis in Compilation Database mode]
-- https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/github-actions-for-sonarcloud/[GitHub Action for C and C++ usage]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/overview/[C/C++/Objective-C analysis overview]
+- https://docs.sonarsource.com/sonarqube-cloud/getting-started/github/[Getting started with GitHub]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/prerequisites/#generating-a-compilation-database[Generating a compilation database]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/running-the-analysis/[Running the CFamily analysis]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/ci-based-analysis/github-actions-for-sonarcloud/[Analyze your repository with GitHub Actions]
 
 = Code Description
 
 An example of a flawed C++ code. The https://github.com/sonarsource-cfamily-examples/code[code repository] can be https://github.com/sonarsource-cfamily-examples/automatic-analysis-sc[analyzed automatically], but it can also be compiled with different build systems using different CI pipelines on Linux, macOS, and Windows.
 
 The https://github.com/sonarsource-cfamily-examples/code[code repository] is forked into other repositories in https://github.com/sonarsource-cfamily-examples[this collection] to add a specific build system, platform, and CI.
-The downstream repositories are analyzed either with https://www.sonarqube.org/[SonarQube] or https://sonarcloud.io/[SonarCloud].
+The downstream repositories are analyzed either with https://www.sonarqube.org/[SonarQube Server] or https://sonarcloud.io/[SonarQube Cloud].
 
 You can find examples for:
 
@@ -64,8 +64,8 @@ Running on the following CI services:
 
 Configured for analysis on:
 
-* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube]
-* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarCloud]
+* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube Server]
+* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarQube Cloud]
 
 You can find also a few examples demonstrating:
 


### PR DESCRIPTION
The [`sonarqube-scan-action@v4.2`](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.1) GHA now handles C, C++, and Objective-C projects even when Build Wrapper is needed, replacing `sonarcloud-github-c-cpp`.

This PR makes the replacement.